### PR TITLE
LPD-62910

### DIFF
--- a/cloud/terraform/aws/backup/modules/backup-plan/main.tf
+++ b/cloud/terraform/aws/backup/modules/backup-plan/main.tf
@@ -1,0 +1,33 @@
+resource "aws_backup_plan" "this" {
+	dynamic "rule" {
+		content {
+			lifecycle {
+				delete_after=rule.value.retention_days
+			}
+			rule_name=rule.value.rule_name
+			schedule=rule.value.schedule
+			start_window=rule.value.start_window_minutes
+			target_vault_name=var.backup_vault_name
+		}
+		for_each=var.backup_rules
+	}
+	name=var.backup_plan_name
+	tags={
+		DeploymentName=var.deployment_name
+	}
+}
+resource "aws_backup_selection" "this" {
+	iam_role_arn=var.backup_service_assumed_role_arn
+	name=var.backup_selection_name
+	plan_id=aws_backup_plan.this.id
+	selection_tag {
+		key="Backup"
+		type="STRINGEQUALS"
+		value="true"
+	}
+	selection_tag {
+		key="DeploymentName"
+		type="STRINGEQUALS"
+		value=var.deployment_name
+	}
+}

--- a/cloud/terraform/aws/backup/modules/backup-plan/outputs.tf
+++ b/cloud/terraform/aws/backup/modules/backup-plan/outputs.tf
@@ -1,0 +1,3 @@
+output "backup_plan_arn" {
+	value=aws_backup_plan.this.arn
+}

--- a/cloud/terraform/aws/backup/modules/backup-plan/variables.tf
+++ b/cloud/terraform/aws/backup/modules/backup-plan/variables.tf
@@ -1,0 +1,35 @@
+variable "backup_plan_name" {
+	default="liferay-backup"
+}
+variable "backup_rules" {
+	default=[
+		{
+			retention_days=30
+			rule_name="daily-backups"
+			schedule="cron(0 5 * * ? *)"
+			start_window_minutes=60
+		}
+	]
+	type=list(
+		object(
+			{
+				retention_days=number
+				rule_name=string
+				schedule=string
+				start_window_minutes=number
+			}
+		)
+	)
+}
+variable "backup_selection_name" {
+	default="by-tags"
+}
+variable "backup_service_assumed_role_arn" {
+	type=string
+}
+variable "backup_vault_name" {
+	default="liferay-backup"
+}
+variable "deployment_name" {
+	default="liferay-self-hosted"
+}

--- a/cloud/terraform/aws/backup/modules/backup-plan/versions.tf
+++ b/cloud/terraform/aws/backup/modules/backup-plan/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+	required_providers {
+		aws={
+			source="hashicorp/aws"
+			version="~> 5.0"
+		}
+	}
+	required_version=">=1.5.0"
+}

--- a/cloud/terraform/aws/backup/modules/backup-vault/main.tf
+++ b/cloud/terraform/aws/backup/modules/backup-vault/main.tf
@@ -1,0 +1,28 @@
+resource "aws_backup_vault" "this" {
+	name=var.backup_vault_name
+}
+resource "aws_iam_role" "this" {
+	assume_role_policy=jsonencode({
+		Statement=[
+			{
+				Action="sts:AssumeRole"
+				Effect="Allow"
+				Principal={
+					Service="backup.amazonaws.com"
+				}
+			}
+		]
+		Version="2012-10-17"
+	})
+	name=var.backup_service_assumed_role_name
+}
+resource "aws_iam_role_policy_attachment" "this" {
+	for_each=toset([
+		"arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup",
+		"arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Restore",
+		"arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup",
+		"arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores",
+	])
+	policy_arn=each.key
+	role=aws_iam_role.this.name
+}

--- a/cloud/terraform/aws/backup/modules/backup-vault/outputs.tf
+++ b/cloud/terraform/aws/backup/modules/backup-vault/outputs.tf
@@ -1,0 +1,6 @@
+output "backup_service_assumed_role_arn" {
+	value=aws_iam_role.this.arn
+}
+output "backup_vault_arn" {
+	value=aws_backup_vault.this.arn
+}

--- a/cloud/terraform/aws/backup/modules/backup-vault/variables.tf
+++ b/cloud/terraform/aws/backup/modules/backup-vault/variables.tf
@@ -1,0 +1,6 @@
+variable "backup_service_assumed_role_name" {
+	default="liferay-backup"
+}
+variable "backup_vault_name" {
+	default="liferay-backup"
+}

--- a/cloud/terraform/aws/backup/modules/backup-vault/versions.tf
+++ b/cloud/terraform/aws/backup/modules/backup-vault/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+	required_providers {
+		aws={
+			source="hashicorp/aws"
+			version="~> 5.0"
+		}
+	}
+	required_version=">=1.5.0"
+}

--- a/cloud/terraform/aws/dependencies/liferay.tf
+++ b/cloud/terraform/aws/dependencies/liferay.tf
@@ -18,6 +18,9 @@ module "s3_bucket" {
 		}
 	}
 	source="terraform-aws-modules/s3-bucket/aws"
+	tags={
+		Backup="true",
+	}
 	version="~> 4.1.1"
 }
 resource "aws_db_instance" "postgres" {
@@ -34,6 +37,7 @@ resource "aws_db_instance" "postgres" {
 	skip_final_snapshot=true
 	storage_type="gp2"
 	tags={
+		Backup="true",
 		Name="${var.deployment_name}-postgres-db"
 	}
 	username=random_password.postgres_username.result


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-62910

I'm going forward with the assumptions that
- Users may want different vaults for different environments (staging, development, production)
- A backup plan should only back up one instance of an application
- Recovery points can be grouped/filtered by the backup vault name, the tags on the backup plan that cascade to the recovery points, and the createdAt timestamp of the recovery point (already tested), to identify what defines a single "backup".

Free to chat more about it if you want.